### PR TITLE
feat(payfast-itn): add server-confirmation + optional IP checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,10 @@ if (!result.isValid) {
 ### Payfast (ITN)
 
 ```ts
-import { verifyWebhookSignature } from "@miniduck/stash";
+import {
+  validatePayfastWebhookSignature,
+  verifyWebhookSignature,
+} from "@miniduck/stash";
 
 const result = verifyWebhookSignature({
   provider: "payfast",
@@ -111,6 +114,24 @@ const result = verifyWebhookSignature({
 
 if (!result.isValid) {
   res.status(400).send("Invalid signature");
+  return;
+}
+```
+
+#### Payfast ITN hardening (signature + server confirmation)
+
+```ts
+import { validatePayfastWebhookSignature } from "@miniduck/stash";
+
+const validation = await validatePayfastWebhookSignature({
+  rawBody: req.rawBody,
+  passphrase: process.env.PAYFAST_PASSPHRASE,
+  mode: "sandbox",
+  validateServer: true,
+});
+
+if (!validation.isValid) {
+  res.status(400).send("Invalid ITN");
   return;
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,21 @@
 import type {
+  PayfastWebhookValidationInput,
+  PayfastWebhookValidationResult,
   PaymentRequest,
   PaymentResponse,
   WebhookVerifyInput,
   WebhookVerifyResult,
 } from "./types.js";
 import { makeOzowPayment, verifyOzowWebhook } from "./providers/ozow.js";
-import { makePayfastPayment, verifyPayfastWebhook } from "./providers/payfast.js";
+import {
+  makePayfastPayment,
+  validatePayfastWebhook,
+  verifyPayfastWebhook,
+} from "./providers/payfast.js";
 
 export type {
+  PayfastWebhookValidationInput,
+  PayfastWebhookValidationResult,
   PaymentProvider,
   PaymentRequest,
   PaymentResponse,
@@ -39,4 +47,10 @@ export function verifyWebhookSignature(
     default:
       throw new Error(`Unsupported provider: ${input.provider}`);
   }
+}
+
+export async function validatePayfastWebhookSignature(
+  input: PayfastWebhookValidationInput
+): Promise<PayfastWebhookValidationResult> {
+  return validatePayfastWebhook(input);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,3 +56,22 @@ export type WebhookVerifyResult = {
   isValid: boolean;
   reason?: string;
 };
+
+export type PayfastWebhookValidationInput = {
+  rawBody: string | Buffer;
+  passphrase?: string;
+  mode?: "live" | "sandbox";
+  validateSignature?: boolean;
+  validateServer?: boolean;
+  validateIp?: boolean;
+  ipAddress?: string;
+  allowedIps?: string[];
+};
+
+export type PayfastWebhookValidationResult = {
+  isValid: boolean;
+  signatureValid: boolean;
+  serverValid?: boolean;
+  ipValid?: boolean;
+  reason?: string;
+};


### PR DESCRIPTION
## Summary
- add a Payfast ITN validation helper that combines signature verification with optional server confirmation and IP allowlisting
- refactor Payfast param-string construction to keep signature generation consistent across verification paths
- expand tests and docs to show how to enable hardening without breaking the existing signature-only flow

## Intuition
- Payfast’s docs recommend checks beyond signatures, so this exposes a safe default path for higher integrity when needed
- the helper keeps advanced validation optional while preserving the simple signature-only API for quick starts
- centralizing parameter handling reduces subtle bugs in encoding/order that can invalidate ITNs

## Testing
- npm test