### PR TITLE
feat(ozow): add transaction status helpers 

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ if (!result.isValid) {
 }
 ```
 
+#### Ozow transaction status check (recommended)
+
+```ts
+import { getOzowTransactionStatusByReference } from "@miniduck/stash";
+
+const status = await getOzowTransactionStatusByReference({
+  siteCode: process.env.OZOW_SITE_CODE,
+  apiKey: process.env.OZOW_API_KEY,
+  transactionReference: "ORDER-12345",
+  testMode: true,
+});
+
+console.log(status.transactions);
+```
+
 ### Payfast (ITN)
 
 ```ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 import type {
+  OzowTransactionQuery,
+  OzowTransactionResult,
   PayfastWebhookValidationInput,
   PayfastWebhookValidationResult,
   PaymentRequest,
@@ -6,7 +8,12 @@ import type {
   WebhookVerifyInput,
   WebhookVerifyResult,
 } from "./types.js";
-import { makeOzowPayment, verifyOzowWebhook } from "./providers/ozow.js";
+import {
+  getOzowTransaction,
+  getOzowTransactionByReference,
+  makeOzowPayment,
+  verifyOzowWebhook,
+} from "./providers/ozow.js";
 import {
   makePayfastPayment,
   validatePayfastWebhook,
@@ -14,6 +21,8 @@ import {
 } from "./providers/payfast.js";
 
 export type {
+  OzowTransactionQuery,
+  OzowTransactionResult,
   PayfastWebhookValidationInput,
   PayfastWebhookValidationResult,
   PaymentProvider,
@@ -53,4 +62,16 @@ export async function validatePayfastWebhookSignature(
   input: PayfastWebhookValidationInput
 ): Promise<PayfastWebhookValidationResult> {
   return validatePayfastWebhook(input);
+}
+
+export async function getOzowTransactionStatusByReference(
+  input: OzowTransactionQuery
+): Promise<OzowTransactionResult> {
+  return getOzowTransactionByReference(input);
+}
+
+export async function getOzowTransactionStatus(
+  input: OzowTransactionQuery
+): Promise<OzowTransactionResult> {
+  return getOzowTransaction(input);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,3 +75,16 @@ export type PayfastWebhookValidationResult = {
   ipValid?: boolean;
   reason?: string;
 };
+
+export type OzowTransactionQuery = {
+  siteCode: string;
+  apiKey: string;
+  transactionReference?: string;
+  transactionId?: string;
+  testMode?: boolean;
+};
+
+export type OzowTransactionResult = {
+  transactions: unknown[];
+  raw: unknown;
+};

--- a/test/ozow-status.test.ts
+++ b/test/ozow-status.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  getOzowTransactionStatus,
+  getOzowTransactionStatusByReference,
+} from "../src/index.js";
+
+test("getOzowTransactionStatusByReference uses staging endpoint in testMode", async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = "";
+
+  globalThis.fetch = (async (url) => {
+    capturedUrl = String(url);
+    return {
+      ok: true,
+      json: async () => [],
+    } as Response;
+  }) as typeof fetch;
+
+  await getOzowTransactionStatusByReference({
+    siteCode: "SITE",
+    apiKey: "API",
+    transactionReference: "REF-1",
+    testMode: true,
+  });
+
+  assert.equal(
+    capturedUrl,
+    "https://stagingapi.ozow.com/GetTransactionByReference?siteCode=SITE&transactionReference=REF-1&isTest=true"
+  );
+
+  globalThis.fetch = originalFetch;
+});
+
+test("getOzowTransactionStatus uses live endpoint by default", async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedUrl = "";
+
+  globalThis.fetch = (async (url) => {
+    capturedUrl = String(url);
+    return {
+      ok: true,
+      json: async () => [],
+    } as Response;
+  }) as typeof fetch;
+
+  await getOzowTransactionStatus({
+    siteCode: "SITE",
+    apiKey: "API",
+    transactionId: "TX-1",
+  });
+
+  assert.equal(
+    capturedUrl,
+    "https://api.ozow.com/GetTransaction?siteCode=SITE&transactionId=TX-1"
+  );
+
+  globalThis.fetch = originalFetch;
+});


### PR DESCRIPTION
## Summary
- add Ozow transaction status helpers for reference- and ID-based lookups with explicit test-mode support
- expose new typed APIs in the public index so post-payment verification is a first-class flow
- add tests and docs that show how to verify transactions after redirects/webhooks

## Intuition
- Ozow recommends checking transaction status beyond redirect payloads, so this makes the safe path easy to adopt
- the helpers centralize endpoint selection and API key usage, reducing integration errors
- typed results keep the SDK consistent and improve discoverability for new users

## Testing
- npm test