### PR TITLE
docs(diataxis): add docs landing page + quickstart entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ Integrate payments in under 15 minutes.
 npm install @miniduck/stash
 ```
 
+## Getting started
+
+Start with the quickstart tutorial: `docs/tutorials/quickstart.md`.
+
+## Docs (Diataxis)
+
+- Tutorials: `docs/tutorials/quickstart.md`
+- How-to guides: `docs/how-to/README.md`
+- Reference: `docs/reference/api.md`
+- Explanation: `docs/explanation/architecture.md`
+
 ## Make a payment
 
 ### Ozow (API)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Docs
+
+This documentation follows the Diataxis framework:
+
+- Tutorials: `docs/tutorials/quickstart.md`
+- How-to guides: `docs/how-to/README.md`
+- Reference: `docs/reference/api.md`
+- Explanation: `docs/explanation/architecture.md`


### PR DESCRIPTION
## Summary
- add a docs landing page that maps to the Diataxis structure
- introduce a Getting started section in README to point users at the quickstart
- list the docs sections to make navigation obvious without removing existing content

## Intuition
- a clear entry point reduces onboarding time and aligns docs with the Diataxis framework
- keeping README intact avoids churn while still guiding readers to the right docs
- the landing page makes future docs growth predictable and discoverable

## Testing
- not run (docs-only changes)