### PR TITLE
docs(webhooks): add raw-body framework examples

### DIFF
--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -20,6 +20,7 @@ You can copy `.env.example` and fill in the values.
 - Make a payment with Payfast: `examples/make-payment-payfast.ts`
 - Verify an Ozow webhook: `examples/webhook-ozow.ts`
 - Verify a Payfast ITN: `examples/webhook-payfast.ts`
+- Verify webhooks safely (raw body): `docs/how-to/webhooks.md`
 - Check Ozow transaction status: `examples/ozow-status.ts`
 - Use webhook form utilities: `examples/webhook-utilities.ts`
 - Send provider-specific fields: `examples/provider-data.ts`

--- a/docs/how-to/webhooks.md
+++ b/docs/how-to/webhooks.md
@@ -1,0 +1,143 @@
+# Verify webhooks with raw body
+
+Webhook verification fails most often when frameworks mutate the request body before you verify it. Always verify against the raw body.
+
+## Common pitfalls
+
+- JSON/body parsers run before verification
+- Whitespace or encoding changes
+- Form field order changes (some providers require it)
+
+## Express
+
+```ts
+import express from "express";
+import { createStash, StashError } from "@miniduck/stash";
+
+const app = express();
+
+const stash = createStash({
+  provider: "payfast",
+  credentials: {
+    merchantId: process.env.PAYFAST_MERCHANT_ID,
+    merchantKey: process.env.PAYFAST_MERCHANT_KEY,
+    passphrase: process.env.PAYFAST_PASSPHRASE,
+  },
+});
+
+app.use(
+  "/webhooks/payfast",
+  express.urlencoded({
+    extended: false,
+    verify: (req, _res, buf) => {
+      (req as any).rawBody = buf.toString("utf8");
+    },
+  })
+);
+
+app.post("/webhooks/payfast", (req, res) => {
+  try {
+    const parsed = stash.webhooks.parse({
+      rawBody: (req as any).rawBody,
+      headers: req.headers,
+    });
+
+    if (parsed.event.type === "payment.completed") {
+      // update order
+    }
+
+    res.status(200).send("OK");
+  } catch (error) {
+    if (error instanceof StashError && error.code === "invalid_signature") {
+      res.status(400).send("Invalid signature");
+      return;
+    }
+    res.status(500).send("Error");
+  }
+});
+```
+
+## Next.js Route Handler (App Router)
+
+```ts
+import { createStash, StashError } from "@miniduck/stash";
+
+const stash = createStash({
+  provider: "ozow",
+  credentials: {
+    siteCode: process.env.OZOW_SITE_CODE,
+    apiKey: process.env.OZOW_API_KEY,
+    privateKey: process.env.OZOW_PRIVATE_KEY,
+  },
+});
+
+export async function POST(request: Request) {
+  try {
+    const rawBody = await request.text();
+    const parsed = stash.webhooks.parse({
+      rawBody,
+      headers: Object.fromEntries(request.headers.entries()),
+    });
+
+    if (parsed.event.type === "payment.completed") {
+      // update order
+    }
+
+    return new Response("OK", { status: 200 });
+  } catch (error) {
+    if (error instanceof StashError && error.code === "invalid_signature") {
+      return new Response("Invalid signature", { status: 400 });
+    }
+    return new Response("Error", { status: 500 });
+  }
+}
+```
+
+## Fastify
+
+```ts
+import Fastify from "fastify";
+import { createStash, StashError } from "@miniduck/stash";
+
+const fastify = Fastify();
+
+const stash = createStash({
+  provider: "payfast",
+  credentials: {
+    merchantId: process.env.PAYFAST_MERCHANT_ID,
+    merchantKey: process.env.PAYFAST_MERCHANT_KEY,
+    passphrase: process.env.PAYFAST_PASSPHRASE,
+  },
+});
+
+fastify.addHook("onRequest", async (request) => {
+  const buffers: Buffer[] = [];
+  for await (const chunk of request.raw) {
+    buffers.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  (request as any).rawBody = Buffer.concat(buffers).toString("utf8");
+});
+
+fastify.post("/webhooks/payfast", async (request, reply) => {
+  try {
+    const parsed = stash.webhooks.parse({
+      rawBody: (request as any).rawBody,
+      headers: request.headers as Record<string, string | string[] | undefined>,
+    });
+
+    if (parsed.event.type === "payment.completed") {
+      // update order
+    }
+
+    reply.code(200).send("OK");
+  } catch (error) {
+    if (error instanceof StashError && error.code === "invalid_signature") {
+      reply.code(400).send("Invalid signature");
+      return;
+    }
+    reply.code(500).send("Error");
+  }
+});
+```
+
+Note: content-type checks are optional and left to the caller.


### PR DESCRIPTION
## Summary
- add a dedicated how-to guide for webhook verification with raw-body handling
- include inline examples for Express, Next.js Route Handlers, and Fastify
- link the guide from the how-to index for discoverability

## Intuition
- most webhook verification failures come from mutated bodies; the examples address that directly
- inline snippets reduce friction and keep guidance close to the API surface
- a focused how-to keeps Diataxis structure clean and actionable

## Testing
- not run (docs-only changes)