### PR TITLE
docs: add skills quick reference page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Start with the quickstart tutorial: `docs/tutorials/quickstart.md`.
 - How-to guides: `docs/how-to/README.md`
 - Reference: `docs/reference/api.md`
 - Explanation: `docs/explanation/architecture.md`
+- Skills quick reference: `doc/skill.md`
 
 ## Examples
 

--- a/doc/skill.md
+++ b/doc/skill.md
@@ -1,0 +1,48 @@
+# Skills
+
+## Common tasks
+
+- Install: `npm install`
+- Build: `npm run build`
+- Test: `npm test`
+- Run examples: `npx tsx examples/make-payment-ozow.ts`
+- Env setup: copy `.env.example` and fill values
+
+## Integration workflows
+
+### Create a payment
+
+Use `createStash` and `payments.create` with a configured provider.
+
+- Ozow: `examples/make-payment-ozow.ts`
+- Payfast: `examples/make-payment-payfast.ts`
+
+### Parse webhooks
+
+Use `stash.webhooks.parse({ rawBody, headers })` and handle canonical events.
+
+- Raw-body patterns: `docs/how-to/webhooks.md`
+- Examples: `examples/webhook-ozow.ts`, `examples/webhook-payfast.ts`
+
+### Optional Ozow status check
+
+Verify payment status after webhook processing.
+
+- `examples/ozow-status.ts`
+
+## Troubleshooting
+
+### Invalid signature (`invalid_signature`)
+
+- Ensure raw body is captured before any parsing
+- Avoid JSON parsing or body mutation prior to verification
+- Preserve encoding and order for form-encoded payloads
+
+### Payfast encoding issues
+
+- URL encoding must use uppercase hex and spaces as `+`
+- Verify field order matches Payfast docs
+
+### Framework raw-body capture
+
+- Express, Next.js Route Handlers, Fastify: `docs/how-to/webhooks.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,4 @@ This documentation follows the Diataxis framework:
 - How-to guides: `docs/how-to/README.md`
 - Reference: `docs/reference/api.md`
 - Explanation: `docs/explanation/architecture.md`
+- Skills quick reference: `doc/skill.md`


### PR DESCRIPTION
## Summary
- add a skills quick reference at `doc/skill.md` for common tasks, workflows, and troubleshooting
- link the skills page from the main README and docs index

## Intuition
- a short, task-focused page makes the most common actions easy to find
- linking from README keeps it discoverable without bloating the main docs

## Testing
- not run (docs-only changes)