### PR TITLE
docs: update skills and changelog for paystack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Return canonical `Payment` and `WebhookEvent` models.
 - Add providerOptions typing and overlap validation.
 - Update docs and examples to the new API.
+- Add Paystack provider support for card checkout, webhooks, and verification.
 
 ## 0.1.0
 

--- a/doc/skill.md
+++ b/doc/skill.md
@@ -16,6 +16,7 @@ Use `createStash` and `payments.create` with a configured provider.
 
 - Ozow: `examples/make-payment-ozow.ts`
 - Payfast: `examples/make-payment-payfast.ts`
+- Paystack: `examples/make-payment-paystack.ts`
 
 ### Parse webhooks
 
@@ -23,12 +24,17 @@ Use `stash.webhooks.parse({ rawBody, headers })` and handle canonical events.
 
 - Raw-body patterns: `docs/how-to/webhooks.md`
 - Examples: `examples/webhook-ozow.ts`, `examples/webhook-payfast.ts`
+- Paystack webhook: `examples/webhook-paystack.ts`
 
 ### Optional Ozow status check
 
 Verify payment status after webhook processing.
 
 - `examples/ozow-status.ts`
+
+### Optional payment verification
+
+- `payments.verify` is supported for Ozow and Paystack
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- update the skills quick reference with Paystack examples and verification notes
- add Paystack support note to the changelog

## Intuition
- keeps the skills page aligned with current providers and capabilities
- ensures release notes reflect Paystack integration

## Testing
- not run (docs-only changes)