### PR TITLE
docs: add contributing guide and license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing
+
+Thanks for helping improve @miniduck/stash. This guide explains how to get set up and what to expect when proposing changes.
+
+## Quick start
+
+```bash
+npm install
+```
+
+## Development workflow
+
+1. Create a branch from `main`.
+2. Make your changes with focused commits.
+3. Run tests before opening a PR.
+4. Open a PR with a clear summary and any relevant context.
+
+## Tests
+
+```bash
+npm test
+```
+
+## Documentation and examples
+
+- Keep README and docs updated when you change behavior or add features.
+- Add or update examples under `examples/` where appropriate.
+
+## Style and correctness
+
+- Prefer small, focused changes.
+- Keep public APIs typed and documented.
+- Add tests for new behavior and edge cases.
+
+## Reporting issues
+
+If you find a bug, open an issue with reproduction steps, expected behavior, and relevant logs or error messages.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Miniduck Co
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- add a full MIT license file at the repository root so downstream users and tooling can clearly identify usage rights
- add a CONTRIBUTING guide that documents the setup command, expected development workflow, and the required test command to run before opening a PR
- document documentation/example update expectations and contribution quality guidelines (small focused changes, typed public APIs, tests for new behavior, clear issue reports)

## Testing
- Not run (docs-only)