### PR TITLE
chore: add release workflow and prep 0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm run build
+
+      - name: Test
+        run: pnpm test
+
+      - name: Extract changelog
+        id: changelog
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          {
+            echo "## $VERSION"
+            awk -v ver="$VERSION" 'BEGIN{flag=0} $0 ~ "^## " ver {flag=1; next} /^## /{flag=0} flag {print}' CHANGELOG.md
+          } > release_notes.txt
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: pnpm publish --access public --no-git-checks
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release_notes.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 AGENTS.md
 node_modules/
 dist/
+.svelte-kit/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 0.1.1
+
+- Add SvelteKit site under `site/` with brand palette and typography.
+- Build a landing page and docs hub that render markdown from `docs/`.
+- Add Dockerfile for local preview on port 5173.
+- Fix docs links to point to docs routes and GitHub examples.
+- Update package scope to `@miniduckco/stash` and refresh description.
+
 - Add `createStash` with capability surfaces for payments and webhooks.
 - Return canonical `Payment` and `WebhookEvent` models.
 - Add providerOptions typing and overlap validation.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@miniduck/stash",
-  "version": "0.1.0",
-  "description": "Unified payments SDK for South Africa (Ozow + Payfast)",
+  "name": "@miniduckco/stash",
+  "version": "0.1.1",
+  "description": "integrate payments. switch once.",
   "license": "MIT",
   "type": "module",
   "main": "./dist/index.js",
@@ -21,7 +21,10 @@
   "scripts": {
     "build": "tsc",
     "test": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\" && npm run build && node --test dist/test/**/*.test.js",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "npm run build",
+    "site:dev": "npm run dev --prefix site -- --host 0.0.0.0 --port 5173",
+    "site:build": "npm run build --prefix site",
+    "site:preview": "npm run preview --prefix site"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",


### PR DESCRIPTION
## Summary
- add a tag-triggered GitHub Actions release workflow that installs dependencies with pnpm, runs build and test, and publishes to npm only when tests pass
- generate GitHub Release notes from the matching `CHANGELOG.md` section so the published release has curated notes
- bump package scope to `@miniduckco/stash` with version `0.1.1` and update the package description for the next publish
- add `.svelte-kit/` to `.gitignore` to avoid build artifacts in commits

## Testing
- Not run locally (CI workflow runs build + test on tag)