### PR TITLE
fix: stabilize test glob for CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add Dockerfile for local preview on port 5173.
 - Fix docs links to point to docs routes and GitHub examples.
 - Update package scope to `@miniduckco/stash` and refresh description.
+- Fix test runner invocation in CI to avoid glob expansion issues.
 
 - Add `createStash` with capability surfaces for payments and webhooks.
 - Return canonical `Payment` and `WebhookEvent` models.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\" && npm run build && node --test dist/test/**/*.test.js",
+    "test": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\" && npm run build && node --test dist/test/*.test.js",
     "prepublishOnly": "npm run build",
     "site:dev": "npm run dev --prefix site -- --host 0.0.0.0 --port 5173",
     "site:build": "npm run build --prefix site",


### PR DESCRIPTION
## Summary
- update the test script to use a simple glob that works in CI shells
- note the CI test fix in the 0.1.1 changelog

## Testing
- npm test