### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@miniduckco/stash",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "integrate payments. switch once.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- update `package.json` to `0.1.3` so the release workflow can publish the new tag